### PR TITLE
Changed file create permissions to 0755 vs 755.

### DIFF
--- a/lib/express-uploader.js
+++ b/lib/express-uploader.js
@@ -401,7 +401,7 @@ module.exports = function Uploader(options) {
                                     }
                                     info.thumbnails.push( thumbSubUrl + thumbName );
 
-                                    var key = util.format('%s_%s', imgData.width, imgData.height);
+                                    var key = util.format('%s', imgData.width);
                                     var path = util.format('%s%s', thumbSubUrl, thumbName);
                                     info.thumbnailObj[key] = thumbSubUrl + thumbName;
 


### PR DESCRIPTION
When resolving full path, set begging of path with os separator to
prevent creation of directories in relative location.

Please let me know if you think setting the beginning path to 'self.settings.osSep' is a valid solution. What I was seeing is that whereever I started the server, it was creating directories for upload right there, not in the base project, or the path where the upload directory was set to if fully qualified. The path.normalize was stripping off the begging separator, and making everything relative. 

Thanks 

Dean 
