### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/express-uploader.js
+++ b/lib/express-uploader.js
@@ -25,7 +25,7 @@
 var fs = require( 'fs' );
 var path = require( 'path' );
 var util = require( 'util' );
-var uuid = require( 'node-uuid' );
+var uuid = require( 'uuid' );
 var gm = require( 'gm' );
 
 var defaultOptions = {

--- a/package.json
+++ b/package.json
@@ -1,52 +1,51 @@
 {
-    "name": "express-uploader",
-    "description": "File uploads with NodeJS",
-    "version": "0.1.3",
-    "main": "./index.js",
-    "scripts": {
-        "test": "node tests/test.js"
-    },
-    "directories": {
-        "lib": "lib",
-        "media": "examples",
-        "tests": "tests"
-    },
-    "homepage": "https://github.com/biggora/express-uploader/",
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/biggora/express-uploader.git"
-    },
-    "author": "Aleksej Gordejev <aleksej@gordejev.lv> (https://github.com/biggora/)",
-    "keywords": [
-        "trinte",
-        "upload",
-        "uploading",
-        "uploader",
-        "express",
-        "middleware",
-        "connect"
-    ],
-    "licenses": {
-        "type": "MIT"
-    },
-    "engines": [
-        "node >= 0.8.0"
-    ],
-    "dependencies": {
-        "gm": ">=1.16.0",
-        "node-uuid": ">=1.4.1"
-    },
-    "devDependencies": {
-        "express": ">=3.0",
-        "connect-multiparty": ">=1.0.3",
-        "morgan": ">=1.0.0",
-        "errorhandler": ">=1.0.0",
-        "compression": ">=1.0.0",
-        "express-session": ">=1.0.0",
-        "body-parser": ">=1.0.0",
-        "method-override": ">=1.0.0",
-        "cookie-parser": ">=1.0.0",
-        "gm": ">=1.14.2",
-        "node-uuid": ">=1.4.1"
-    }
+  "name": "express-uploader",
+  "description": "File uploads with NodeJS",
+  "version": "0.1.3",
+  "main": "./index.js",
+  "scripts": {
+    "test": "node tests/test.js"
+  },
+  "directories": {
+    "lib": "lib",
+    "media": "examples",
+    "tests": "tests"
+  },
+  "homepage": "https://github.com/biggora/express-uploader/",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/biggora/express-uploader.git"
+  },
+  "author": "Aleksej Gordejev <aleksej@gordejev.lv> (https://github.com/biggora/)",
+  "keywords": [
+    "trinte",
+    "upload",
+    "uploading",
+    "uploader",
+    "express",
+    "middleware",
+    "connect"
+  ],
+  "licenses": {
+    "type": "MIT"
+  },
+  "engines": [
+    "node >= 0.8.0"
+  ],
+  "dependencies": {
+    "gm": ">=1.16.0",
+    "uuid": "^3.0.0"
+  },
+  "devDependencies": {
+    "express": ">=3.0",
+    "connect-multiparty": ">=1.0.3",
+    "morgan": ">=1.0.0",
+    "errorhandler": ">=1.0.0",
+    "compression": ">=1.0.0",
+    "express-session": ">=1.0.0",
+    "body-parser": ">=1.0.0",
+    "method-override": ">=1.0.0",
+    "cookie-parser": ">=1.0.0",
+    "gm": ">=1.14.2"
+  }
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.