### PR TITLE
Document express-uploader test and release automation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    environment: npm-publish
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Ensure npm supports trusted publishing
+        run: npm install -g npm@^11.5.1
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test
+
+      - name: Verify package contents
+        run: npm publish --dry-run
+
+      - name: Publish package
+        run: npm publish

--- a/README.md
+++ b/README.md
@@ -11,12 +11,39 @@ To install express-uploader:
 
 ## Development
 
-For development, after cloning the repository, install dependencies and build the project:
+For development, after cloning the repository, install dependencies and run the
+test suite:
 
-    $ npm install
+    $ npm ci
+    $ npm test
+
+The default test command runs `vitest run`.
+
+Useful maintainer commands:
+
     $ npm run build
+    $ npm run test:legacy
+    $ npm run test:comprehensive
+    $ npm run lint
+    $ npm run typecheck
 
-This will compile the TypeScript source files to JavaScript in the `dist` directory.
+## CI and release automation
+
+GitHub Actions uses `.github/workflows/unit-tests.yml` for test automation. The
+workflow runs on `push` and `pull_request`, installs dependencies with `npm ci`,
+and runs `npm test` on Node.js 22 and 24.
+
+Publishing is handled by `.github/workflows/publish.yml`. The publish workflow
+runs only for pushed tags that match `v*`, uses the protected GitHub environment
+named `npm-publish`, installs npm `^11.5.1`, runs `npm ci`, runs `npm test`,
+checks package contents with `npm publish --dry-run`, and then runs
+`npm publish`.
+
+The npm publish path uses GitHub Actions OIDC Trusted Publishing. Do not add
+`NODE_AUTH_TOKEN`, `NPM_TOKEN`, or a `registry-url` setting to this workflow.
+Before the first release tag is pushed, configure npm Trusted Publishing for
+package `express-uploader` with repository `biggora/express-uploader`, workflow
+`.github/workflows/publish.yml`, and environment `npm-publish`.
 
 ## Usage overview
 


### PR DESCRIPTION
## Summary

- Updates the README development section to document `npm ci`, `npm test`, and the maintainer scripts now present on the workflow branch.
- Documents `.github/workflows/unit-tests.yml` behavior for push and pull request CI on Node.js 22 and 24.
- Adds and documents `.github/workflows/publish.yml` for tag-based npm publishing through GitHub Actions OIDC Trusted Publishing, using the `npm-publish` environment and no npm token path.

This PR is stacked on `codex/ope-189-unit-test-workflow` because the documentation depends on the unit-test workflow and Vitest test scripts from OPE-188/OPE-189.

## Verification

- `npm ci`
- `npm test` (1 file, 7 tests passed)
- `npm exec -- prettier --check README.md .github/workflows/publish.yml`
- `git diff --check -- README.md .github/workflows/publish.yml`
- README fenced-code review: balanced fences

## Note

Before the first `v*` release tag is pushed, the Human Owner still needs to configure npm Trusted Publishing for package `express-uploader` with repository `biggora/express-uploader`, workflow `.github/workflows/publish.yml`, and environment `npm-publish`.